### PR TITLE
Remove `deborphan`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Rules-Requires-Root: no
 
 Package: legacy-dist
 Architecture: all
-Depends: ${misc:Depends}, helper-scripts, apt-forktracer, deborphan
+Depends: ${misc:Depends}, helper-scripts, apt-forktracer
 Provides: vbox-disable-timesync, whonix-legacy
 Replaces: vbox-disable-timesync, whonix-legacy
 Conflicts: vbox-disable-timesync, whonix-legacy

--- a/usr/sbin/release-upgrade
+++ b/usr/sbin/release-upgrade
@@ -199,9 +199,6 @@ dpkg-noninteractive --configure -a
 true "INFO: Showing unofficial packages packages (excluding Whonix and Qubes) (pre):"
 apt-forktracer | grep --invert-match "whonix:" | grep --invert-match "Qubes Debian:" || true
 
-true "INFO: Running deborphan (pre)..."
-deborphan
-
 true "INFO: Fetching package lists (1/2)..."
 
 ## TODO: This can fail if the oldstable repository is no longer available.
@@ -322,9 +319,6 @@ dpkg-noninteractive --configure -a
 
 true "INFO: Showing unofficial packages packages (excluding Whonix and Qubes) (post):"
 apt-forktracer | grep --invert-match "whonix:" | grep --invert-match "Qubes Debian:" || true
-
-true "INFO: Running deborphan (post)..."
-deborphan
 
 ## Risky. User should review and do manually.
 ## /wiki/Debian_Packages#Re-install_Meta_Packages_and_Safely_Run_Autoremove


### PR DESCRIPTION
This pull request changes...

## Changes

`deborphan` was removed from Debian Sid in Bug 1065312; it is not present in Debian Trixie and higher (except that it still exists in Sid for `riscv64` for... some reason).

Removing `deborphan` from Kicksecure dependencies fixes issues when distro-morphing Debian Trixie and higher to Kicksecure. It is also necessary for installing Kicksecure on ports-only architectures such as `ppc64`.

Debian bug 1074134 (asking for suggested alternatives) remains open, but it doesn't look like it's going to be fixed anytime soon, so I think we should cut our losses and remove it from Kicksecure now, and maybe add an alternative later once one exists.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
    * It definitely fixes the conflict on `ppc64`, but I can't test beyond that due to a 2nd (independent) conflict that I'm working on another PR for.
- [ ] I have reviewed and updated any documentation if relevant
    * I don't think there's any pertinent docs here?
- [ ] I am providing new code and test(s) for it
    * No new code, just deleted code.
